### PR TITLE
Fix images in built website

### DIFF
--- a/src/content/docs/features/multicolored-highlights.mdx
+++ b/src/content/docs/features/multicolored-highlights.mdx
@@ -5,7 +5,7 @@ description: This is a guide on activating multicolored highlights.
 
 import { Steps } from '@astrojs/starlight/components';
 
-![Multicolored Highlights in Primary](/src/media/demos/notes-files_multicolored-highlights.png)
+![Multicolored Highlights in Primary](../../media/demos/notes-files_multicolored-highlights.png)
 
 Primary offers Multicolored Highlights out of the box. This can be activated by combining 2 or more markdown syntaxes.
 

--- a/src/content/docs/guides/font-recommendations/karla.mdx
+++ b/src/content/docs/guides/font-recommendations/karla.mdx
@@ -6,7 +6,7 @@ tableOfContents: false
 
 import { Steps } from '@astrojs/starlight/components';
 
-![Karla for Primary](/src/media/demos/font-recom_karla.png)
+![Karla for Primary](../../media/demos/font-recom_karla.png)
 
 Karla is a great sans serif font for those who want to add quirkiness to Primary. 
 

--- a/src/content/docs/start-here.mdx
+++ b/src/content/docs/start-here.mdx
@@ -27,37 +27,37 @@ This documentation site is underconstruction. The site currently works best in L
 
 #### Desktop
 
-![Primary for Obsidian on Desktop - Light Mode](/src/media/previews/desktop-1_light-mode.png)
+![Primary for Obsidian on Desktop - Light Mode](../../media/previews/desktop-1_light-mode.png)
 
-![Primary for Obsidian on Desktop - Light Mode](/src/media/previews/desktop-2_light-mode.png)
+![Primary for Obsidian on Desktop - Light Mode](../../media/previews/desktop-2_light-mode.png)
 
-![Primary for Obsidian on Desktop - Light Mode](/src/media/previews/desktop-3_light-mode.png)
+![Primary for Obsidian on Desktop - Light Mode](../../media/previews/desktop-3_light-mode.png)
 
 #### Tablet
 
-![Primary for Obsidian on Tablet - Light Mode](/src/media/previews/tablet-1_light-mode.png)
+![Primary for Obsidian on Tablet - Light Mode](../../media/previews/tablet-1_light-mode.png)
 
 #### Mobile
 
-![Primary for Obsidian on Mobile - Light Mode](/src/media/previews/mobile-1_light-mode.png)
+![Primary for Obsidian on Mobile - Light Mode](../../media/previews/mobile-1_light-mode.png)
 
 ### Dark Mode
 
 #### Desktop
 
-![Primary for Obsidian on Desktop - Dark Mode](/src/media/previews/desktop-1_dark-mode.png)
+![Primary for Obsidian on Desktop - Dark Mode](../../media/previews/desktop-1_dark-mode.png)
 
-![Primary for Obsidian on Desktop - Dark Mode](/src/media/previews/desktop-2_dark-mode.png)
+![Primary for Obsidian on Desktop - Dark Mode](../../media/previews/desktop-2_dark-mode.png)
 
-![Primary for Obsidian on Desktop - Dark Mode](/src/media/previews/desktop-3_dark-mode.png)
+![Primary for Obsidian on Desktop - Dark Mode](../../media/previews/desktop-3_dark-mode.png)
 
 #### Tablet
 
-![Primary for Obsidian on Tablet - Dark Mode](/src/media/previews/tablet-1_dark-mode.png)
+![Primary for Obsidian on Tablet - Dark Mode](../../media/previews/tablet-1_dark-mode.png)
 
 #### Mobile
 
-![Primary for Obsidian on Mobile - Dark Mode](/src/media/previews/mobile-1_dark-mode.png)
+![Primary for Obsidian on Mobile - Dark Mode](../../media/previews/mobile-1_dark-mode.png)
 
 
 ## Installation


### PR DESCRIPTION
According to [Astro docs](https://docs.astro.build/en/guides/images/#images-in-mdx-files), images in .mdx files should be referenced by their relative path, not absolute one. Indeed, by doing that and after running `npm run build` and inspecting the contents of the `dist` directory, they appeared there under `_astro` subdirectory (also converted to .webp format).

This should fix the assets in a deployed website.